### PR TITLE
Dev andres

### DIFF
--- a/Backend/app/db/squemas/products_squemas.py
+++ b/Backend/app/db/squemas/products_squemas.py
@@ -1,9 +1,17 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
-class Product(BaseModel):
-    nombre : str
-    sku : str
-    descripcion : str | None = None
-    stock : int
-    stock_minimo : int
+class ProductoCreate(BaseModel):
+    nombre: str
+    sku: str
+    stock: int = 0
+    stock_minimo: int = 0
+    descripcion: str | None = None   #Atributo opcional, por defecto esta vacio
 
+class ProductoResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)  # permite mapear desde ORM (Lo que permite transformar de modelo ORM o modelo dominio a un JSON, que es lo que tiene que devolver un ENDPOINT)
+    id: int
+    nombre: str
+    sku: str
+    stock: int
+    stock_minimo: int
+    descripcion: str | None

--- a/Backend/app/repositories/product_repository.py
+++ b/Backend/app/repositories/product_repository.py
@@ -1,0 +1,49 @@
+from sqlalchemy.orm import Session
+from app.db.models_ORM.product_orm import ProductoORM
+from app.mappers.mapper_product import orm_a_dominio, dominio_a_orm
+from app.domain.product import Producto
+
+class ProductoRepository:
+    def __init__(self, session: Session):
+        self.session = session
+
+    def obtener_por_id(self, producto_id: int) -> Producto | None:
+
+        orm_obj = self.session.get(ProductoORM, producto_id)
+        return orm_a_dominio(orm_obj) if orm_obj else None
+
+    def listar(self) -> list[Producto]:
+        return [orm_a_dominio(p) for p in self.session.query(ProductoORM).all()]
+
+    def agregar(self, producto: Producto) -> Producto:
+        orm_obj = dominio_a_orm(producto)
+        self.session.add(orm_obj)
+        self.session.commit()
+        self.session.refresh(orm_obj)
+        return orm_a_dominio(orm_obj)
+    
+    def editar(self, producto: Producto):
+        orm_obj = self.session.get(ProductoORM, producto.id)
+
+        if not orm_obj:
+            raise ValueError(f"Producto con ID {producto.id} no encontrado")
+        
+        orm_obj.nombre = producto.nombre
+        orm_obj.sku = producto.sku
+        orm_obj.stock = producto.stock
+        orm_obj.stock_minimo = producto.stock_minimo
+        orm_obj.descripcion = producto.descripcion
+
+        self.session.commit()
+        self.session.refresh(orm_obj)
+
+        return orm_a_dominio(orm_obj)
+    
+    def eliminar(self, producto_id:int):
+        orm_obj = self.session.get(ProductoORM, producto_id)
+
+        if not orm_obj:
+            raise ValueError(f"Producto con ID {producto_id} no encontrado")
+        
+        self.session.delete(orm_obj)
+        self.session.commit()


### PR DESCRIPTION
## Cree el repositorio del producto

Esta es la capa que **desacopla la logica de negocio con la persistencia**. El microservicio del Producto va a hacer uso de esta capa. Esta capa utiliza el **mapper** para devolverle a la API un modelo del dominio del Producto o para persistir en la DDBB un modelo ORM.

##  Modifique el squema del producto

- Separe el squema en dos: uno para la entrada y otro para la salida.
- Agregue "ConfigDict" que permite que Pydantic pueda mapper modelos de dominio u ORM y transformarlos a JSON.

