### PR TITLE
Dev andres - Paginacion y numeracion de listados

### DIFF
--- a/Backend/app/db/squemas/products_squemas.py
+++ b/Backend/app/db/squemas/products_squemas.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, ConfigDict
+from typing import List
 
 class ProductoCreate(BaseModel):
     nombre: str
@@ -15,3 +16,10 @@ class ProductoResponse(BaseModel):
     stock: int
     stock_minimo: int
     descripcion: str | None
+
+class PaginacionProductos(BaseModel):
+    page: int
+    limit: int
+    total_items: int
+    total_pages: int
+    items: List[ProductoResponse]

--- a/Backend/app/repositories/product_repository.py
+++ b/Backend/app/repositories/product_repository.py
@@ -36,10 +36,17 @@ class ProductoRepository:
 
         """
 
-        total_items = query.count()   # Primera Query
-        total_pages = (total_items + limit - 1) // limit  # redondeo hacia arriba
+        total_items = query.count()   # Primera Query, cuenta el total de registros.
+
+        total_pages = (total_items + limit - 1) // limit  # Formula para obtener el total de "paginas"
 
         productos_orm = query.offset((page - 1) * limit).limit(limit).all()     #Segunda Query
+        
+        """
+        #El metodo offser(N), ignora los primeros N registros que le indiquemos. Si le concatenamos el metodo limit().
+        Estamos creando una consulta que va a traer los primeros 10 registros que haya desde la pagina que le indiquemos.
+
+        """
 
         productos = [orm_a_dominio(p) for p in productos_orm]   #La query devolvio una lista de objetos ProductoORM, aca se transforman a modelos de dominio.
 

--- a/Backend/app/repositories/product_repository.py
+++ b/Backend/app/repositories/product_repository.py
@@ -2,6 +2,7 @@ from sqlalchemy.orm import Session
 from app.db.models_ORM.product_orm import ProductoORM
 from app.mappers.mapper_product import orm_a_dominio, dominio_a_orm
 from app.domain.product import Producto
+from app.db.squemas.products_squemas import PaginacionProductos
 
 class ProductoRepository:
     def __init__(self, session: Session):
@@ -12,8 +13,48 @@ class ProductoRepository:
         orm_obj = self.session.get(ProductoORM, producto_id)
         return orm_a_dominio(orm_obj) if orm_obj else None
 
-    def listar(self) -> list[Producto]:
-        return [orm_a_dominio(p) for p in self.session.query(ProductoORM).all()]
+
+
+    def listar(self, page=1, limit=10) -> PaginacionProductos:
+
+        query = self.session.query(ProductoORM).order_by(ProductoORM.id)   
+
+        """
+        Destripando la linea de cod:
+
+            self.session.query(ProductoORM):
+
+            Crea un objeto Query que representa SELECT * FROM productos, pero todavía no pega a la BD.
+            Esto te permite encadenar filtros, orden, etc., antes de ejecutar.
+
+            Hasta que no utilices un metodo terminal la query no se va a ejecutar. (all(), first(), one(), count(), etc)
+
+            order_by(ProductoORM.id):
+            
+            Para paginación estable, siempre se agrega un order_by (ej. por id). Sin orden, el motor puede devolver filas
+            en un orden no determinístico y te puede “bailar” la paginación.
+
+        """
+
+        total_items = query.count()   # Primera Query
+        total_pages = (total_items + limit - 1) // limit  # redondeo hacia arriba
+
+        productos_orm = query.offset((page - 1) * limit).limit(limit).all()     #Segunda Query
+
+        productos = [orm_a_dominio(p) for p in productos_orm]   #La query devolvio una lista de objetos ProductoORM, aca se transforman a modelos de dominio.
+
+        return {
+            "page": page,
+            "limit": limit,
+            "total_items": total_items,
+            "total_pages": total_pages,
+            "items": productos
+        }
+
+        
+
+
+
 
     def agregar(self, producto: Producto) -> Producto:
         orm_obj = dominio_a_orm(producto)


### PR DESCRIPTION
## Paginación y numeración a listados

Se refiere a cuando consultás un listado de productos (o de **cualquier entidad**), que la **API** no devuelva **todo de golpe**, sino que lo parta en **páginas** y además le agregue información sobre:

- Qué página estoy viendo
- Cuántos registros hay en total
- Cuántas páginas existen
- Cuántos registros tiene la página actual

### ¿Cómo se implementa?

- En el repositorio: usando **.offset()** y **.limit()** de SQLAlchemy para traer solo la **porción de datos**. (tanto offset como limit son nativos de SQL). El metodo del repositorio que tiene la funcion de listar va a recibir dos parametros; page y limit) 
- En el endpoint: se reciben parámetros (page, limit). Usualmente pasados como parametros por query.
- En la respuesta: además de los productos, devolvés la metadata de paginación (total de registros, total de páginas, página actual). Metadata = informacion.

👉 Esto mejora el rendimiento (no traés 10.000 filas de una sola vez) y da control al cliente (puede ir navegando por páginas).